### PR TITLE
Fix fatal error with method_exists() call

### DIFF
--- a/xili-language/xili-includes/class-xili-language.php
+++ b/xili-language/xili-includes/class-xili-language.php
@@ -2187,7 +2187,7 @@ class Xili_Language {
 	// to fixe event in WP 3.4 - 2.7.1
 	public function xili_test_lang_perma() {
 		global $xl_permalinks_rules;
-		$this->lang_perma = ( class_exists( 'XL_Permalinks_Rules' ) && method_exists( $xl_permalinks_rules, 'insert_lang_tag_root' ) ); // 2.9.23 - must have instanciation in theme
+		$this->lang_perma = ( class_exists( 'XL_Permalinks_Rules' ) && ! empty( $xl_permalinks_rules ) && method_exists( $xl_permalinks_rules, 'insert_lang_tag_root' ) ); // 2.9.23 - must have instanciation in theme
 		$this->lpr = '-'; // 2.16.6
 	}
 


### PR DESCRIPTION
Hi,

We are seeing a fatal error with the plugin due to the global `$xl_permalinks_rules` variable being `null` when doing a `method_exists()` check.

This PR does a check to see if the `$xl_permalinks_rules` global is empty or not before the `method_exists()` call is made to prevent the fatal.